### PR TITLE
refactor: remove deprecated @types/react-pdf and related dependencies

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -64,7 +64,6 @@
         "@types/react": "18.2.14",
         "@types/react-copy-to-clipboard": "^5.0.4",
         "@types/react-dom": "^18.0.10",
-        "@types/react-pdf": "^6.2.0",
         "@types/react-syntax-highlighter": "^15.5.6",
         "autoprefixer": "^10.4.13",
         "eslint": "8.43.0",
@@ -1501,16 +1500,6 @@
         "@types/react": "*"
       }
     },
-    "node_modules/@types/react-pdf": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmmirror.com/@types/react-pdf/-/react-pdf-6.2.0.tgz",
-      "integrity": "sha512-OSCYmrfaJvpXkM5V4seUMAhUDOAOqbGQf9kwv14INyTf7AjDs2ukfkkQrLWRQ8OjWrDklbXYWh5l7pT7l0N76g==",
-      "dev": true,
-      "dependencies": {
-        "@types/react": "*",
-        "pdfjs-dist": "^2.16.105"
-      }
-    },
     "node_modules/@types/react-syntax-highlighter": {
       "version": "15.5.7",
       "resolved": "https://registry.npmmirror.com/@types/react-syntax-highlighter/-/react-syntax-highlighter-15.5.7.tgz",
@@ -2883,13 +2872,6 @@
       "funding": {
         "url": "https://github.com/fb55/domhandler?sponsor=1"
       }
-    },
-    "node_modules/dommatrix": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmmirror.com/dommatrix/-/dommatrix-1.0.3.tgz",
-      "integrity": "sha512-l32Xp/TLgWb8ReqbVJAFIvXmY7go4nTxxlWiAFyhoQw9RKEOHBZNnyGvJWqDVSPmq3Y9HlM4npqF/T6VMOXhww==",
-      "deprecated": "dommatrix is no longer maintained. Please use @thednp/dommatrix.",
-      "dev": true
     },
     "node_modules/domutils": {
       "version": "3.2.2",
@@ -6633,24 +6615,6 @@
       "resolved": "https://registry.npmmirror.com/path-webpack/-/path-webpack-0.0.3.tgz",
       "integrity": "sha512-AmeDxedoo5svf7aB3FYqSAKqMxys014lVKBzy1o/5vv9CtU7U4wgGWL1dA2o6MOzcD53ScN4Jmiq6VbtLz1vIQ=="
     },
-    "node_modules/pdfjs-dist": {
-      "version": "2.16.105",
-      "resolved": "https://registry.npmmirror.com/pdfjs-dist/-/pdfjs-dist-2.16.105.tgz",
-      "integrity": "sha512-J4dn41spsAwUxCpEoVf6GVoz908IAA3mYiLmNxg8J9kfRXc2jxpbUepcP0ocp0alVNLFthTAM8DZ1RaHh8sU0A==",
-      "dev": true,
-      "dependencies": {
-        "dommatrix": "^1.0.3",
-        "web-streams-polyfill": "^3.2.1"
-      },
-      "peerDependencies": {
-        "worker-loader": "^3.0.8"
-      },
-      "peerDependenciesMeta": {
-        "worker-loader": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmmirror.com/picocolors/-/picocolors-1.0.0.tgz",
@@ -8814,15 +8778,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmmirror.com/web-namespaces/-/web-namespaces-2.0.1.tgz",
       "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ=="
-    },
-    "node_modules/web-streams-polyfill": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmmirror.com/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
-      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
-      "dev": true,
-      "engines": {
-        "node": ">= 8"
-      }
     },
     "node_modules/webworkify-webpack": {
       "version": "2.1.5",

--- a/app/package.json
+++ b/app/package.json
@@ -67,7 +67,6 @@
     "@types/react": "18.2.14",
     "@types/react-copy-to-clipboard": "^5.0.4",
     "@types/react-dom": "^18.0.10",
-    "@types/react-pdf": "^6.2.0",
     "@types/react-syntax-highlighter": "^15.5.6",
     "autoprefixer": "^10.4.13",
     "eslint": "8.43.0",


### PR DESCRIPTION
This pull request includes several dependency removals from the `package-lock.json` and `package.json` files. The main focus is on removing unused or deprecated packages.

Dependency removals:

* Removed `@types/react-pdf` from `package.json` and `package-lock.json` as it is no longer needed. [[1]](diffhunk://#diff-baa935e47c548c1c2375e84a25203d60d0c81efae59289e5f5f5bdf7a4047c9aL67) [[2]](diffhunk://#diff-012b982f97a0d326aeec58dd3b789484b05a944d609afe1b8ed5e299fc485f61L70)
* Removed `dommatrix` from `package-lock.json` due to its deprecation.
* Removed `pdfjs-dist` and its dependencies from `package-lock.json`.
* Removed `web-streams-polyfill` from `package-lock.json`.